### PR TITLE
Fixed a bug after refunding unspoiled product is also saved that as a waste

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ tests/database.sqlite-journal
 tests/Post/*
 storage/snapshots/*.sql
 .idea
+.php-cs-fixer.php

--- a/app/Services/ExpenseService.php
+++ b/app/Services/ExpenseService.php
@@ -552,7 +552,7 @@ class ExpenseService
 
         $this->recordCashFlowHistory( $expense );
 
-        if ( OrderProductRefund::CONDITION_DAMAGED ) {
+        if ( $orderProductRefund->condition == OrderProductRefund::CONDITION_DAMAGED ) {
             /**
              * Only if the product is damaged we should
              * consider saving that as a waste.


### PR DESCRIPTION
Hi @Blair2004 
**issue** : after refunding unspoiled product is also saved that as a waste
