### PR TITLE
fix POS customer selection owed amount

### DIFF
--- a/resources/ts/popups/ns-pos-customer-select-popup.vue
+++ b/resources/ts/popups/ns-pos-customer-select-popup.vue
@@ -39,8 +39,8 @@
                             <small class="text-xs text-fontcolor-soft" v-else>{{ __( 'No Group Assigned' ) }}</small>
                         </div>
                         <p class="flex items-center">
-                            <span v-if="customer.owe_amount > 0" class="text-error-primary">-{{ nsCurrency( customer.owe_amount ) }}</span>
-                            <span v-if="customer.owe_amount > 0">/</span>
+                            <span v-if="customer.owed_amount > 0" class="text-error-primary">-{{ nsCurrency( customer.owed_amount ) }}</span>
+                            <span v-if="customer.owed_amount > 0">/</span>
                             <span class="purchase-amount">{{ nsCurrency( customer.purchases_amount ) }}</span>
                             <button @click="openCustomerHistory( customer, $event )" class="mx-2 rounded-full h-8 w-8 flex items-center justify-center border ns-inset-button info">
                                 <i class="las la-eye"></i>
@@ -63,8 +63,12 @@ import nsPosCustomersVue from './ns-pos-customers.vue';
 import { __ } from '~/libraries/lang';
 import { nsCurrency } from '~/filters/currency';
 import popupCloser from '~/libraries/popup-closer';
+import { Order } from "~/interfaces/order";
+import { Customer } from "~/interfaces/customer";
 
 declare const POS;
+
+type SelectableCustomer = Customer & { selected?: boolean }
 
 export default {
     props: [ 'popup' ],
@@ -72,15 +76,10 @@ export default {
         return {
             searchCustomerValue: '',
             orderSubscription: null,
-            order: {},
+            order: {} as Order,
             debounceSearch: null,
-            customers: [],
+            customers: [] as SelectableCustomer[],
             isLoading: false,
-        }
-    },
-    computed: {
-        customerSelected() {
-            return false;
         }
     },
     watch: {
@@ -130,7 +129,7 @@ export default {
             Popup.show( nsPosCustomersVue, { customer, activeTab: 'account-payment' });
         },
 
-        selectCustomer( customer ) {
+        selectCustomer( customer: SelectableCustomer ) {
             this.customers.forEach( customer => customer.selected = false );
             customer.selected   =   true;
 
@@ -150,7 +149,7 @@ export default {
         searchCustomer( value ) {
             nsHttpClient.post( '/api/customers/search', {
                 search: value
-            }).subscribe( customers => {
+            }).subscribe( (customers: SelectableCustomer[]) => {
                 customers.forEach( customer => customer.selected = false );
                 this.customers  =   customers;
             })
@@ -166,7 +165,7 @@ export default {
 
             nsHttpClient.get( '/api/customers/recently-active' )
                 .subscribe({
-                    next: customers => {
+                    next: (customers: SelectableCustomer[]) => {
                         this.isLoading  =   false;
                         customers.forEach( customer => customer.selected = false );
                         this.customers  =   customers;

--- a/resources/ts/popups/ns-pos-customers.vue
+++ b/resources/ts/popups/ns-pos-customers.vue
@@ -153,7 +153,7 @@
                                                                         <h3 class="font-bold">{{ __( 'Transaction' ) }}: {{ getWalletHistoryLabel( history.operation ) }}</h3>
                                                                         <div class="md:-mx-2 w-full flex flex-col md:flex-row">
                                                                             <div class="md:px-2 flex items-start w-full md:w-1/3">
-                                                                                <small>{{ __( 'Amount' ) }}: {{ nsCurrency( amount ) }}</small>
+                                                                                <small>{{ __( 'Amount' ) }}: {{ nsCurrency( history.amount ) }}</small>
                                                                             </div>
                                                                             <div class="md:px-2 flex items-start w-full md:w-1/3">
                                                                                 <small>{{ __( 'Date' ) }}: {{ history.created_at }}</small>
@@ -205,7 +205,7 @@
                                                                         ({{ coupon.coupon.discount_value }}%)
                                                                     </span>
                                                                     <span v-if="coupon.coupon.type === 'flat_discount'">
-                                                                        ({{ nsCurrency( value ) }})
+                                                                        ({{ nsCurrency( coupon.coupon.discount_value ) }})
                                                                     </span>
                                                                 </td>
                                                                 <td class="border p-2 text-right">


### PR DESCRIPTION
- The customer selection dialog used a wrong field name (`owe_amount` instead of `owed_amount`) and thus owed amount was never shown. This MR fixes the issue and adds type information for better compile-time validation (that should detect and prevent such issues in future).
- The customer dialog used wrong field names for wallet history amount and (percentage type) coupon values