### PR TITLE
fix pending order currency formatting

### DIFF
--- a/resources/ts/popups/ns-pos-pending-orders.vue
+++ b/resources/ts/popups/ns-pos-pending-orders.vue
@@ -41,6 +41,7 @@
 <script lang="ts">
 import { __ } from '~/libraries/lang';
 import popupCloser from '~/libraries/popup-closer';
+import { nsCurrency } from "~/filters/currency";
 
 declare const nsHooks;
 
@@ -79,10 +80,10 @@ export default {
                 value: ( order ) => order.user_username
             }, {
                 label: __( 'Total' ),
-                value: ( order ) => order.total
+                value: ( order ) => nsCurrency(order.total)
             }, {
                 label: __( 'Tendered' ),
-                value: ( order ) => order.tendered
+                value: ( order ) => nsCurrency(order.tendered)
             },
         ]);
 


### PR DESCRIPTION
Fixes a small formatting issue in the orders POS popup. Note the wrong currency formatting in the dialog.

BEFORE:
<img width="1050" height="1095" alt="grafik" src="https://github.com/user-attachments/assets/410ae702-7d56-4c2a-aba9-063be598feb0" />
AFTER:
<img width="1063" height="1084" alt="grafik" src="https://github.com/user-attachments/assets/32b1a5cb-f4e4-427f-bd45-7f83fa27e376" />
