### PR TITLE
fix order products popup price

### DIFF
--- a/resources/ts/popups/ns-pos-order-products-popup.vue
+++ b/resources/ts/popups/ns-pos-order-products-popup.vue
@@ -62,7 +62,7 @@ export default {
                     <div class="flex-col border-b border-info-primary py-2">
                         <div class="title font-semibold text-fontcolor flex justify-between">
                             <span>{{ product.name }} (x{{ product.quantity }})</span>
-                            <span>{{ nsCurrency( price ) }}</span>
+                            <span>{{ nsCurrency( product.total_price ) }}</span>
                         </div>
                         <div class="text-sm text-font">
                             <ul>


### PR DESCRIPTION
Fixes wrong price (always zero) in POS -> order -> products popup.
BEFORE:
<img width="1123" height="291" alt="grafik" src="https://github.com/user-attachments/assets/ef7e214c-0e46-4b5b-a45b-d33cef378411" />
AFTER:
<img width="1119" height="225" alt="grafik" src="https://github.com/user-attachments/assets/dad57363-7d7f-471b-b8bc-0ee1a450877e" />
